### PR TITLE
Add 2026 World Cup results - 17 June (4 matches)

### DIFF
--- a/goalscorers.csv
+++ b/goalscorers.csv
@@ -47662,3 +47662,16 @@ date,home_team,away_team,team,scorer,minute,own_goal,penalty
 2026-06-16,Iraq,Norway,Norway,Erling Haaland,43,FALSE,FALSE
 2026-06-16,Iraq,Norway,Norway,Leo Østigård,76,FALSE,FALSE
 2026-06-16,Iraq,Norway,Norway,Aymen Hussein,90,TRUE,FALSE
+2026-06-17,Portugal,DR Congo,Portugal,João Neves,6,FALSE,FALSE
+2026-06-17,Portugal,DR Congo,DR Congo,Yoane Wissa,45,FALSE,FALSE
+2026-06-17,England,Croatia,England,Harry Kane,12,FALSE,TRUE
+2026-06-17,England,Croatia,Croatia,Martin Baturina,36,FALSE,FALSE
+2026-06-17,England,Croatia,England,Harry Kane,42,FALSE,FALSE
+2026-06-17,England,Croatia,Croatia,Petar Musa,45,FALSE,FALSE
+2026-06-17,England,Croatia,England,Jude Bellingham,47,FALSE,FALSE
+2026-06-17,England,Croatia,England,Marcus Rashford,85,FALSE,FALSE
+2026-06-17,Ghana,Panama,Ghana,Caleb Yirenkyi,90,FALSE,FALSE
+2026-06-17,Uzbekistan,Colombia,Colombia,Daniel Muñoz,40,FALSE,FALSE
+2026-06-17,Uzbekistan,Colombia,Uzbekistan,Abbosbek Fayzullaev,60,FALSE,FALSE
+2026-06-17,Uzbekistan,Colombia,Colombia,Luis Díaz,65,FALSE,FALSE
+2026-06-17,Uzbekistan,Colombia,Colombia,Jaminton Campaz,90,FALSE,FALSE

--- a/results.csv
+++ b/results.csv
@@ -49424,10 +49424,10 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2026-06-16,Iraq,Norway,1,4,FIFA World Cup,Foxborough,United States,TRUE
 2026-06-16,Argentina,Algeria,3,0,FIFA World Cup,Kansas City,United States,TRUE
 2026-06-16,Austria,Jordan,3,1,FIFA World Cup,Santa Clara,United States,TRUE
-2026-06-17,Portugal,DR Congo,NA,NA,FIFA World Cup,Houston,United States,TRUE
-2026-06-17,Uzbekistan,Colombia,NA,NA,FIFA World Cup,Mexico City,Mexico,TRUE
-2026-06-17,England,Croatia,NA,NA,FIFA World Cup,Arlington,United States,TRUE
-2026-06-17,Ghana,Panama,NA,NA,FIFA World Cup,Toronto,Canada,TRUE
+2026-06-17,Portugal,DR Congo,1,1,FIFA World Cup,Houston,United States,TRUE
+2026-06-17,Uzbekistan,Colombia,1,3,FIFA World Cup,Mexico City,Mexico,TRUE
+2026-06-17,England,Croatia,4,2,FIFA World Cup,Arlington,United States,TRUE
+2026-06-17,Ghana,Panama,1,0,FIFA World Cup,Toronto,Canada,TRUE
 2026-06-18,Czech Republic,South Africa,NA,NA,FIFA World Cup,Atlanta,United States,TRUE
 2026-06-18,Mexico,South Korea,NA,NA,FIFA World Cup,Zapopan,Mexico,FALSE
 2026-06-18,Switzerland,Bosnia and Herzegovina,NA,NA,FIFA World Cup,Inglewood,United States,TRUE


### PR DESCRIPTION
Results and goalscorers for four 2026 FIFA World Cup group-stage matches played on 17 June 2026:
- Portugal 1-1 DR Congo
- England 4-2 Croatia
- Ghana 1-0 Panama
- Uzbekistan 1-3 Colombia

results.csv: filled the scores on the four existing fixture rows.
goalscorers.csv: 13 goal rows (Kane's 12' was a penalty;).