### PR TITLE
Add Papua New Guinea goalscorers from 1980 Oceania Cup

### DIFF
--- a/goalscorers.csv
+++ b/goalscorers.csv
@@ -8696,10 +8696,10 @@ date,home_team,away_team,team,scorer,minute,own_goal,penalty
 1980-02-24,New Caledonia,Australia,Australia,Eddie Krncevic,NA,FALSE,FALSE
 1980-02-24,New Caledonia,Australia,Australia,Eddie Krncevic,NA,FALSE,FALSE
 1980-02-24,New Caledonia,Australia,Australia,Eddie Krncevic,NA,FALSE,FALSE
-1980-02-24,Vanuatu,Papua New Guinea,Papua New Guinea,NA,NA,FALSE,FALSE
-1980-02-24,Vanuatu,Papua New Guinea,Papua New Guinea,NA,NA,FALSE,FALSE
-1980-02-24,Vanuatu,Papua New Guinea,Papua New Guinea,NA,NA,FALSE,FALSE
-1980-02-24,Vanuatu,Papua New Guinea,Papua New Guinea,NA,NA,FALSE,FALSE
+1980-02-24,Vanuatu,Papua New Guinea,Papua New Guinea,Aeriel Kaore,25,FALSE,FALSE
+1980-02-24,Vanuatu,Papua New Guinea,Papua New Guinea,Sanar Asugum,82,FALSE,TRUE
+1980-02-24,Vanuatu,Papua New Guinea,Papua New Guinea,Andy Dedeba,NA,FALSE,FALSE
+1980-02-24,Vanuatu,Papua New Guinea,Papua New Guinea,Tikio Piska,NA,FALSE,FALSE
 1980-02-24,Vanuatu,Papua New Guinea,Vanuatu,NA,NA,FALSE,FALSE
 1980-02-24,Vanuatu,Papua New Guinea,Vanuatu,NA,NA,FALSE,FALSE
 1980-02-24,Vanuatu,Papua New Guinea,Vanuatu,NA,NA,FALSE,FALSE


### PR DESCRIPTION
## Summary
- add four Papua New Guinea goalscorers for the 1980-02-24 Oceania Nations Cup match against Vanuatu
- include the two available goal minutes and mark Sanar Asugum's goal as a penalty
- leave the three Vanuatu goalscorers as `NA` because the available source still marks the match as partially missing

## Source
- National Football Teams match report: https://www.national-football-teams.com/matches/report/42898/Papua_New_Guinea_Vanuatu.html

## Validation
- parsed all CSV files with Python
- checked the 1980-02-24 Vanuatu v Papua New Guinea scorer counts still match the 3-4 result

Closes #46 partially.