### PR TITLE
Fix 2026 World Cup Round of 16 match dates

### DIFF
--- a/results.csv
+++ b/results.csv
@@ -49498,8 +49498,8 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2026-07-05,Mexico,England,2,3,FIFA World Cup,Mexico City,Mexico,FALSE
 2026-07-06,Portugal,Spain,0,1,FIFA World Cup,Dallas,United States,TRUE
 2026-07-06,United States,Belgium,1,4,FIFA World Cup,Seattle,United States,FALSE
-2026-07-06,Argentina,Egypt,NA,NA,FIFA World Cup,Atlanta,United States,TRUE
-2026-07-06,Switzerland,Colombia,NA,NA,FIFA World Cup,Vancouver,Canada,TRUE
+2026-07-07,Argentina,Egypt,NA,NA,FIFA World Cup,Atlanta,United States,TRUE
+2026-07-07,Switzerland,Colombia,NA,NA,FIFA World Cup,Vancouver,Canada,TRUE
 2026-07-09,France,Morocco,NA,NA,FIFA World Cup,Foxborough,United States,TRUE
 2026-07-10,Spain,Belgium,NA,NA,FIFA World Cup,Inglewood,United States,TRUE
 2026-07-11,Norway,England,NA,NA,FIFA World Cup,Miami Gardens,United States,TRUE


### PR DESCRIPTION
## Summary

This PR corrects the dates for two 2026 FIFA World Cup Round of 16 matches from July 6 to July 7, 2026.

## Changes

| Match | Old Date | New Date |
|-------|----------|----------|
| Argentina vs Egypt | 2026-07-06 | **2026-07-07** |
| Switzerland vs Colombia | 2026-07-06 | **2026-07-07** |

## Reference

According to the official 2026 FIFA World Cup schedule on Wikipedia:
- **Argentina vs Egypt** - Atlanta, United States - July 7, 2026
- **Switzerland vs Colombia** - Vancouver, Canada - July 7, 2026

Source: https://en.wikipedia.org/wiki/2026_FIFA_World_Cup#Knockout_stage

## Files Changed

- `results.csv`: Updated date field for both matches