### PR TITLE
Update 2026 World Cup: July 11 Quarter-Final Results

### DIFF
--- a/goalscorers.csv
+++ b/goalscorers.csv
@@ -47890,3 +47890,10 @@ date,home_team,away_team,team,scorer,minute,own_goal,penalty
 2026-07-10,Spain,Belgium,Spain,Fabián Ruiz,30,FALSE,FALSE
 2026-07-10,Spain,Belgium,Belgium,Charles De Ketelaere,41,FALSE,FALSE
 2026-07-10,Spain,Belgium,Spain,Mikel Merino,88,FALSE,FALSE
+2026-07-11,Norway,England,Norway,Andreas Schjelderup,36,FALSE,FALSE
+2026-07-11,Norway,England,England,Jude Bellingham,47,FALSE,FALSE
+2026-07-11,Norway,England,England,Jude Bellingham,93,FALSE,FALSE
+2026-07-11,Argentina,Switzerland,Argentina,Alexis Mac Allister,10,FALSE,FALSE
+2026-07-11,Argentina,Switzerland,Switzerland,Dan Ndoye,67,FALSE,FALSE
+2026-07-11,Argentina,Switzerland,Argentina,Julián Alvarez,112,FALSE,FALSE
+2026-07-11,Argentina,Switzerland,Argentina,Lautaro Martínez,121,FALSE,FALSE

--- a/results.csv
+++ b/results.csv
@@ -49502,5 +49502,7 @@ date,home_team,away_team,home_score,away_score,tournament,city,country,neutral
 2026-07-07,Switzerland,Colombia,0,0,FIFA World Cup,Vancouver,Canada,TRUE
 2026-07-09,France,Morocco,2,0,FIFA World Cup,Foxborough,United States,TRUE
 2026-07-10,Spain,Belgium,2,1,FIFA World Cup,Inglewood,United States,TRUE
-2026-07-11,Norway,England,NA,NA,FIFA World Cup,Miami Gardens,United States,TRUE
-2026-07-11,Argentina,Switzerland,NA,NA,FIFA World Cup,Kansas City,United States,TRUE
+2026-07-11,Norway,England,1,2,FIFA World Cup,Miami Gardens,United States,TRUE
+2026-07-11,Argentina,Switzerland,3,1,FIFA World Cup,Kansas City,United States,TRUE
+2026-07-14,France,Spain,NA,NA,FIFA World Cup,Arlington,United States,TRUE
+2026-07-15,England,Argentina,NA,NA,FIFA World Cup,Atlanta,United States,TRUE


### PR DESCRIPTION
This PR updates the 2026 FIFA World Cup data with the completed July 11 quarter-final matches.

## Changes Made:

### results.csv
- Updated Norway vs England: 1-2 (after extra time)
- Updated Argentina vs Switzerland: 3-1 (after extra time)

### goalscorers.csv
Added goalscorers for:
- Norway vs England:
  - Andreas Schjelderup (36') - Norway
  - Jude Bellingham (45+2', 93') - England (brace, winner in ET)
  
- Argentina vs Switzerland:
  - Alexis Mac Allister (10') - Argentina
  - Dan Ndoye (67') - Switzerland
  - Julián Alvarez (112') - Argentina (ET)
  - Lautaro Martínez (120+1') - Argentina (ET)

## Data Sources:
- Wikipedia: 2026 FIFA World Cup knockout stage
- FIFA official match reports

Both matches went to extra time with England and Argentina advancing to the semi-finals.